### PR TITLE
Add maxDecompress, maxFileWrites, separate download, decompres and file write operation to improve network utilization

### DIFF
--- a/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
+++ b/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
@@ -41,12 +41,12 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive

--- a/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
+++ b/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
@@ -50,7 +50,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex

--- a/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
+++ b/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
@@ -40,7 +40,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
@@ -49,7 +48,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch

--- a/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
+++ b/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
@@ -1528,8 +1528,8 @@ class DepotDownloader @JvmOverloads constructor(
         listeners.remove(listener)
     }
 
-    private fun notifyListeners(action: (IDownloadListener) -> Unit) {
-        scope.launch(Dispatchers.Main) {
+    private suspend fun notifyListeners(action: (IDownloadListener) -> Unit) {
+        coroutineScope {
             listeners.forEach { listener -> action(listener) }
         }
     }

--- a/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
+++ b/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
@@ -1522,8 +1522,10 @@ class DepotDownloader @JvmOverloads constructor(
         listeners.remove(listener)
     }
 
-    private fun notifyListeners(action: (IDownloadListener) -> Unit) {
-        listeners.forEach { listener -> action(listener) }
+    private suspend fun notifyListeners(action: (IDownloadListener) -> Unit) {
+        coroutineScope {
+            listeners.forEach { listener -> action(listener) }
+        }
     }
 
     // endregion

--- a/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
+++ b/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
@@ -1528,8 +1528,8 @@ class DepotDownloader @JvmOverloads constructor(
         listeners.remove(listener)
     }
 
-    private suspend fun notifyListeners(action: (IDownloadListener) -> Unit) {
-        coroutineScope {
+    private fun notifyListeners(action: (IDownloadListener) -> Unit) {
+        scope.launch(Dispatchers.Main) {
             listeners.forEach { listener -> action(listener) }
         }
     }

--- a/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
+++ b/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
@@ -104,6 +104,7 @@ import kotlin.text.toLongOrNull
  * @param maxDecompress Number of concurrent chunk decompress. Default: 8
  * @param maxFileWrites Number of concurrent files being written. Default: 1
  * @param androidEmulation Forces "Windows" as the default OS filter. Used when running Android games in PC emulators that expect Windows builds.
+ * @param parentJob Parent job for the downloader. If provided, the downloader will be cancelled when the parent job is cancelled.
  *
  * @author Oxters
  * @author Lossy
@@ -120,6 +121,7 @@ class DepotDownloader @JvmOverloads constructor(
     private var maxDecompress: Int = 8,
     private var maxFileWrites: Int = 1,
     private val androidEmulation: Boolean = false,
+    private val parentJob: Job? = null,
 ) : Closeable {
 
     companion object {
@@ -153,7 +155,7 @@ class DepotDownloader @JvmOverloads constructor(
 
     private val progressUpdateInterval = 500L // ms
 
-    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob(parentJob))
 
     private var cdnClientPool: CDNClientPool? = null
 

--- a/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
+++ b/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
@@ -1467,7 +1467,7 @@ class DepotDownloader @JvmOverloads constructor(
         file: FileData,
         fileStreamData: FileStreamData,
         chunk: ChunkData,
-    ): DecompressItem? = withContext(Dispatchers.Default) {
+    ): DecompressItem? = withContext(Dispatchers.IO) {
         ensureActive()
 
         val depot = depotFilesData.depotDownloadInfo

--- a/src/main/java/in/dragonbra/javasteam/steam/cdn/Client.kt
+++ b/src/main/java/in/dragonbra/javasteam/steam/cdn/Client.kt
@@ -202,14 +202,8 @@ class Client(steamClient: SteamClient) : Closeable {
     ): Int = withContext(Dispatchers.IO) {
         require(chunk.chunkID != null) { "Chunk must have a ChunkID." }
 
-        if (depotKey == null) {
-            if (destination.size < chunk.compressedLength) {
-                throw IllegalArgumentException("The destination buffer must be longer than the chunk CompressedLength (since no depot key was provided).")
-            }
-        } else {
-            if (destination.size != chunk.compressedLength) {
-                throw IllegalArgumentException("The destination buffer must be the same size as the chunk UncompressedLength.")
-            }
+        if (destination.size != chunk.compressedLength) {
+            throw IllegalArgumentException("The destination buffer must be the same size as the chunk CompressedLength (Since we take out decompression step from download")
         }
 
         val chunkID = Strings.toHex(chunk.chunkID)
@@ -360,6 +354,16 @@ class Client(steamClient: SteamClient) : Closeable {
 
         scope.launch {
             try {
+                if (depotKey != null) {
+                    if (destination.size < chunk.compressedLength) {
+                        throw IllegalArgumentException("The destination buffer must be longer than the chunk CompressedLength (since no depot key was provided).")
+                    }
+                } else {
+                    if (destination.size != chunk.compressedLength) {
+                        throw IllegalArgumentException("The destination buffer must be the same size as the chunk UncompressedLength.")
+                    }
+                }
+
                 val downloadedBytes = ByteArray(chunk.compressedLength)
 
                 val bytesDownloaded = downloadDepotChunk(


### PR DESCRIPTION
Add maxFileWrites, separate download and file write operation to improve network utilization.

### Description
When using GN 0.6.0 to download the game, the download time is not very good as each of the download job is bounded to the file write operation. Sepearating file write operation and download operation could make the download process smoother and faster.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [ ] Samples run successfully
- [x] Extended the README / documentation, if necessary
