### PR TITLE
Improves Zstd and Zip handling

### DIFF
--- a/src/main/java/in/dragonbra/javasteam/types/KeyValue.kt
+++ b/src/main/java/in/dragonbra/javasteam/types/KeyValue.kt
@@ -323,7 +323,7 @@ class KeyValue @JvmOverloads constructor(
      * @param asBinary If set to <c>true</c>, saves this instance as binary.
      */
     fun saveToFile(file: File, asBinary: Boolean) {
-        FileOutputStream(file, false).use { f -> saveToStream(f, asBinary) }
+        FileOutputStream(file, false).buffered().use { f -> saveToStream(f, asBinary) }
     }
 
     /**
@@ -332,7 +332,7 @@ class KeyValue @JvmOverloads constructor(
      * @param asBinary If set to <c>true</c>, saves this instance as binary.
      */
     fun saveToFile(path: String, asBinary: Boolean) {
-        FileOutputStream(path, false).use { f -> saveToStream(f, asBinary) }
+        FileOutputStream(path, false).buffered().use { f -> saveToStream(f, asBinary) }
     }
 
     /**
@@ -473,7 +473,7 @@ class KeyValue @JvmOverloads constructor(
             }
 
             try {
-                FileInputStream(file).use { input ->
+                FileInputStream(file).buffered(8192).use { input ->
                     val kv = KeyValue()
 
                     if (asBinary) {

--- a/src/main/java/in/dragonbra/javasteam/types/KeyValue.kt
+++ b/src/main/java/in/dragonbra/javasteam/types/KeyValue.kt
@@ -323,7 +323,7 @@ class KeyValue @JvmOverloads constructor(
      * @param asBinary If set to <c>true</c>, saves this instance as binary.
      */
     fun saveToFile(file: File, asBinary: Boolean) {
-        FileOutputStream(file, false).buffered().use { f -> saveToStream(f, asBinary) }
+        FileOutputStream(file, false).use { f -> saveToStream(f, asBinary) }
     }
 
     /**
@@ -332,7 +332,7 @@ class KeyValue @JvmOverloads constructor(
      * @param asBinary If set to <c>true</c>, saves this instance as binary.
      */
     fun saveToFile(path: String, asBinary: Boolean) {
-        FileOutputStream(path, false).buffered().use { f -> saveToStream(f, asBinary) }
+        FileOutputStream(path, false).use { f -> saveToStream(f, asBinary) }
     }
 
     /**
@@ -473,7 +473,7 @@ class KeyValue @JvmOverloads constructor(
             }
 
             try {
-                FileInputStream(file).buffered(8192).use { input ->
+                FileInputStream(file).use { input ->
                     val kv = KeyValue()
 
                     if (asBinary) {


### PR DESCRIPTION
Refactors Zstd decompression to use streaming to avoid long JNI critical locks, improving memory management.

Removes unnecessary buffering from KeyValue file operations.

### Description
Please explain the changes you made here.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [] Samples run successfully
- [x] Extended the README / documentation, if necessary
