### PR TITLE
Update dd-logs

### DIFF
--- a/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
+++ b/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
@@ -248,9 +248,7 @@ class DepotDownloader @JvmOverloads constructor(
         }
 
         if (autoStartDownload) {
-            scope.launch {
-                processItems()
-            }
+            startDownloading()
         }
     }
 

--- a/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
+++ b/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
@@ -1630,7 +1630,7 @@ class DepotDownloader @JvmOverloads constructor(
     }
 
     private fun notifyListeners(action: (IDownloadListener) -> Unit) {
-        scope.launch(Dispatchers.Main) {
+        scope.launch(Dispatchers.IO) {
             listeners.forEach { listener -> action(listener) }
         }
     }

--- a/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
+++ b/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
@@ -106,6 +106,7 @@ import kotlin.text.toLongOrNull
  * @param maxFileWrites Number of concurrent files being written. Default: 1
  * @param androidEmulation Forces "Windows" as the default OS filter. Used when running Android games in PC emulators that expect Windows builds.
  * @param parentJob Parent job for the downloader. If provided, the downloader will be cancelled when the parent job is cancelled.
+ * @param autoStartDownload Whether to start downloading automatically. If false, you must call [startDownloading] manually.
  *
  * @author Oxters
  * @author Lossy
@@ -123,6 +124,7 @@ class DepotDownloader @JvmOverloads constructor(
     private var maxFileWrites: Int = 1,
     private val androidEmulation: Boolean = false,
     private val parentJob: Job? = null,
+    private val autoStartDownload: Boolean = true,
 ) : Closeable {
 
     companion object {
@@ -242,6 +244,12 @@ class DepotDownloader @JvmOverloads constructor(
         licenses.forEach { license ->
             if (license.accessToken.toULong() > 0UL) {
                 steam3!!.packageTokens[license.packageID] = license.accessToken
+            }
+        }
+
+        if (autoStartDownload) {
+            scope.launch {
+                processItems()
             }
         }
     }

--- a/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
+++ b/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
@@ -1199,7 +1199,7 @@ class DepotDownloader @JvmOverloads constructor(
                 // Cancel the continuous flow job since no more chunks will be added
                 chunkProcessingJob?.cancel()
 
-                logger?.debug("Canceled chunk processing job for depot ${depot.depotId}")
+                if (debug) logger?.debug("Canceled chunk processing job for depot ${depot.depotId}")
             }
         }
 

--- a/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
+++ b/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
@@ -1600,7 +1600,18 @@ class DepotDownloader @JvmOverloads constructor(
     private suspend fun finishDepotDownload(mainAppId: Int) {
         val appItem = processingItemsMap[mainAppId]
         if (appItem != null) {
+            if (debug) {
+                logger?.debug("Notifying onDownloadCompleted")
+            }
             notifyListeners { it.onDownloadCompleted(appItem) }
+        } else {
+            if (debug) {
+                logger?.error("AppItem not found, cannot notify onDownloadCompleted")
+            }
+        }
+
+        if (debug) {
+            logger?.debug("Complete the completionFuture.")
         }
 
         completionFuture.complete(null)
@@ -1619,7 +1630,7 @@ class DepotDownloader @JvmOverloads constructor(
     }
 
     private fun notifyListeners(action: (IDownloadListener) -> Unit) {
-        scope.launch(Dispatchers.IO) {
+        scope.launch(Dispatchers.Main) {
             listeners.forEach { listener -> action(listener) }
         }
     }

--- a/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
+++ b/javasteam-depotdownloader/src/main/kotlin/in/dragonbra/javasteam/depotdownloader/DepotDownloader.kt
@@ -244,7 +244,9 @@ class DepotDownloader @JvmOverloads constructor(
                 steam3!!.packageTokens[license.packageID] = license.accessToken
             }
         }
+    }
 
+    fun startDownloading() {
         // Launch the processing loop
         scope.launch {
             processItems()
@@ -952,6 +954,8 @@ class DepotDownloader @JvmOverloads constructor(
                     "(${downloadCounter.totalBytesUncompressed} bytes uncompressed) from ${depots.size} depots"
             )
         }
+
+        finishDepotDownload(mainAppId)
     }
 
     private suspend fun processDepotManifestAndFiles(
@@ -1244,10 +1248,6 @@ class DepotDownloader @JvmOverloads constructor(
         }
 
         if (debug) logger?.debug("Depot ${depot.depotId} - Downloaded ${depotCounter.depotBytesCompressed} bytes (${depotCounter.depotBytesUncompressed} bytes uncompressed)")
-
-        if (isLastDepot) {
-            finishDepotDownload(mainAppId)
-        }
     }
 
     private suspend fun downloadSteam3DepotFile(

--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_023_downloadapp/SampleDownloadApp.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_023_downloadapp/SampleDownloadApp.java
@@ -306,6 +306,9 @@ public class SampleDownloadApp implements Runnable, IDownloadListener {
             // Once all items in queue are done, 'completion' will signal that everything had finished.
             depotDownloader.finishAdding();
 
+            // Start downloading.
+            depotDownloader.startDownloading();
+
             // Block until we're done downloading.
             // Note: If you did not call `finishAdding()` before awaiting, depotDownloader will be expecting
             // more items to be added to queue. It may look like a hang. You could call `close()` to finish too.

--- a/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_023_downloadapp/SampleDownloadApp.java
+++ b/javasteam-samples/src/main/java/in/dragonbra/javasteamsamples/_023_downloadapp/SampleDownloadApp.java
@@ -306,9 +306,6 @@ public class SampleDownloadApp implements Runnable, IDownloadListener {
             // Once all items in queue are done, 'completion' will signal that everything had finished.
             depotDownloader.finishAdding();
 
-            // Start downloading.
-            depotDownloader.startDownloading();
-
             // Block until we're done downloading.
             // Note: If you did not call `finishAdding()` before awaiting, depotDownloader will be expecting
             // more items to be added to queue. It may look like a hang. You could call `close()` to finish too.


### PR DESCRIPTION
Prevents unnecessary logging of chunk processing job cancellation in non-debug mode.

This change reduces log clutter by only logging the cancellation of the chunk processing job when the debug flag is enabled.

### Description
Please explain the changes you made here.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [ ] Samples run successfully
- [x] Extended the README / documentation, if necessary
